### PR TITLE
Fix RSK to BTC Hashrate Percentage issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -413,16 +413,8 @@ var nodeCleanupTimeout = setInterval( function ()
 
 }, NODE_CLEANUP_INTERVAL);
 
-const usePrimaryBtcHashrateProvider = require('./lib/utils/config').usePrimaryBtcHashrateProvider;
-
-const btcHashrateUpdater = setInterval(() =>
-{
-	if(usePrimaryBtcHashrateProvider) {
-		Nodes.updateBtcHashrate('https://sochain.com/api/v2/get_info/BTC');
-	} else {
-		// Nodes.updateBtcHashrateFromBackUp('https://api.blockchain.info/stats');
-		Nodes.updateBtcHashrateFromBraiinsAPI('https://insights.braiins.com/api/v1.0/hashrate-stats');
-	}
+const btcHashrateUpdater = setInterval(() => {
+	Nodes.updateBtcHashrate();
 }, BTC_HASHRATE_UPDATE_INTERVAL);
 
 server.listen(process.env.PORT || 3000);

--- a/app.js
+++ b/app.js
@@ -6,6 +6,11 @@ var http = require('http');
 // Init WS SECRET
 var WS_SECRET;
 
+// Constants
+const LATENCY_TIMEOUT_INTERVAL = 5000; // 5 seconds
+const NODE_CLEANUP_INTERVAL = 1000*60*60 // 60 minutes
+const BTC_HASHRATE_UPDATE_INTERVAL = 1000*60*60; // 60 minutes
+
 if( !_.isUndefined(process.env.WS_SECRET) && !_.isNull(process.env.WS_SECRET) )
 {
 	if( process.env.WS_SECRET.indexOf('|') > 0 )
@@ -393,7 +398,7 @@ var latencyTimeout = setInterval( function ()
 			serverTime: _.now()
 		}
 	});
-}, 5000);
+}, LATENCY_TIMEOUT_INTERVAL);
 
 
 // Cleanup old inactive nodes
@@ -406,7 +411,7 @@ var nodeCleanupTimeout = setInterval( function ()
 
 	Nodes.getCharts();
 
-}, 1000*60*60);
+}, NODE_CLEANUP_INTERVAL);
 
 const usePrimaryBtcHashrateProvider = require('./lib/utils/config').usePrimaryBtcHashrateProvider;
 
@@ -415,9 +420,10 @@ const btcHashrateUpdater = setInterval(() =>
 	if(usePrimaryBtcHashrateProvider) {
 		Nodes.updateBtcHashrate('https://sochain.com/api/v2/get_info/BTC');
 	} else {
-		Nodes.updateBtcHashrateFromBackUp('https://api.blockchain.info/stats');
+		// Nodes.updateBtcHashrateFromBackUp('https://api.blockchain.info/stats');
+		Nodes.updateBtcHashrateFromBraiinsAPI('https://insights.braiins.com/api/v1.0/hashrate-stats');
 	}
-}, 1000*10);
+}, BTC_HASHRATE_UPDATE_INTERVAL);
 
 server.listen(process.env.PORT || 3000);
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -343,6 +343,10 @@ Collection.prototype.updateBtcHashrateFromBackUp = function(source)
 	this._blockchain.updateBtcHashrateFromBackUpExternalSource(source);
 }
 
+Collection.prototype.updateBtcHashrateFromBraiinsAPI = function(source) {
+	this._blockchain.updateBtcHashrateFromBraiinsAPI(source);
+}
+
 Collection.prototype.updateBtcHashrateFromAlternativeBackUp = function(source)
 {
 	this._blockchain.updateBtcHashrateFromAlternativeBackUpExternalSource(source);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -333,23 +333,8 @@ Collection.prototype.askedForHistory = function(set)
 	return (this._askedForHistory || _.now() - this._askedForHistoryTime < 2*60*1000);
 }
 
-Collection.prototype.updateBtcHashrate = function(source)
-{
-	this._blockchain.updateBtcHashrateFromExternalSource(source);
-}
-
-Collection.prototype.updateBtcHashrateFromBackUp = function(source)
-{
-	this._blockchain.updateBtcHashrateFromBackUpExternalSource(source);
-}
-
-Collection.prototype.updateBtcHashrateFromBraiinsAPI = function(source) {
-	this._blockchain.updateBtcHashrateFromBraiinsAPI(source);
-}
-
-Collection.prototype.updateBtcHashrateFromAlternativeBackUp = function(source)
-{
-	this._blockchain.updateBtcHashrateFromAlternativeBackUpExternalSource(source);
+Collection.prototype.updateBtcHashrate = function() {
+	this._blockchain.updateBtcHashrate();
 }
 
 module.exports = Collection;

--- a/lib/history.js
+++ b/lib/history.js
@@ -14,17 +14,13 @@ var MAX_UNCLES = 1000;
 var MAX_UNCLES_PER_BIN = 25;
 var MAX_BINS = 40;
 
-// Adjust this value as needed as the network grows
-// Note: the reasoning here was that in general, the RSK network
-// hashrate fluctuates around 60% (this can be checked on the mining reports).
-var MAX_RSK_HASHRATE_PERCENTAGE = 61.52;
-
 var History = function History(data)
 {
 	this._items = [];
 	this._callback = null;
 	this._networkHashrate = 0;
 	this._btcHashrate = 0;
+	this._btcHashratePercentage = 0;
 }
 
 History.prototype.add = function(block, id, trusted, addingHistory)
@@ -667,22 +663,21 @@ History.prototype.getHistoryRequestRange = function()
 	};
 }
 
-History.prototype.getHashrateComparedToBtcNetwork = function()
-{
+History.prototype.getHashrateComparedToBtcNetwork = function() {
 	const rskHashrate = this.getAvgNetworkHashrate();
 	const btcHashrate = this.getBtcAvgNetworkHashrate();
-	if (rskHashrate === 0 || btcHashrate === 0){
-		return 0;
+	
+	var percentage = this._btcHashratePercentage;
+	if (rskHashrate != 0 && btcHashrate != 0) {
+		percentage = rskHashrate * 100 / btcHashrate;
 	}
 
-	const percentage = rskHashrate * 100 / btcHashrate;
+	// Only save the new value if it's between 0 and 100
+	if (percentage >= 0 && percentage <= 100) {
+		this._btcHashratePercentage = percentage;
+	}
 
-	// TODO -> Fix me!
-	// This is done as a temporal fix as these value fluctuates a lot due to
-	// some bug (probably on the API that returns the btcHashrate)
-	if (percentage > MAX_RSK_HASHRATE_PERCENTAGE) return MAX_RSK_HASHRATE_PERCENTAGE;
-
-	return percentage < 1 ? 0 : percentage;
+	return this._btcHashratePercentage < 1 ? 0 : this._btcHashratePercentage;
 }
 
 function tryParseJSON (jsonString, customErrorMessage){
@@ -755,6 +750,36 @@ History.prototype.updateBtcHashrateFromBackUpExternalSource = function(source)
 
 	}).on("error", (err) => {
 		console.error("Error while retrieving BTC hash rate: " + err.message);
+	});
+}
+
+// This API returns the BTC current hashrate value in EH/s
+History.prototype.updateBtcHashrateFromBraiinsAPI = function(source) {
+	https.get(source, (resp) => {
+		let data = '';
+
+		resp.on('data', (chunk) => {
+			data += chunk;
+		});
+
+		resp.on('end', () => {
+			const parsedData = tryParseJSON(data, "Failed to update BTC hashrate. Unable to parse JSON response");
+			if (!parsedData || !parsedData.hasOwnProperty("current_hashrate")) {
+				return;
+			}
+			
+			const oldBtcHashrate = this._btcHashrate;
+			const btcHashrateInEH = parsedData.current_hashrate;
+			this._btcHashrate = btcHashrateInEH * 1E18; // Convert from EH to H
+
+			// trigger client update
+			if (oldBtcHashrate !== this._btcHashrate) {
+				this.getCharts();
+			}
+		});
+
+	}).on("error", (err) => {
+		console.error("Error while retrieving BTC hash rate: ", err.message);
 	});
 }
 

--- a/lib/history.js
+++ b/lib/history.js
@@ -699,66 +699,11 @@ function tryParseJSON (jsonString, customErrorMessage){
 	return false;
 }
 
-History.prototype.updateBtcHashrateFromExternalSource = function(source)
-{
-	https.get(source, (resp) => {
-		let data = '';
-
-		resp.on('data', (chunk) => {
-			data += chunk;
-		});
-
-		resp.on('end', () => {
-			const parsedData = tryParseJSON(data, "Failed to update BTC hashrate. Unable to parse JSON response");
-		
-			if (!parsedData || !parsedData.hasOwnProperty("data") || !parsedData.data.hasOwnProperty("hashrate")){
-				return;
-			}
-			const oldBtcHashrate = this._btcHashrate;
-			this._btcHashrate = parsedData.data.hashrate
-			// trigger client update
-			if(oldBtcHashrate !== this._btcHashrate) {
-				this.getCharts();
-			}
-		});
-
-	}).on("error", (err) => {
-		console.error("Error while retrieving BTC hash rate: " + err.message);
-	});
-}
-
-History.prototype.updateBtcHashrateFromBackUpExternalSource = function(source)
-{
-	https.get(source, (resp) => {
-		let data = '';
-
-		resp.on('data', (chunk) => {
-			data += chunk;
-		});
-
-		resp.on('end', () => {
-			const parsedData = tryParseJSON(data, "Failed to update BTC hashrate. Unable to parse JSON response");
-			if (!parsedData || !parsedData.hasOwnProperty("hash_rate")){
-				return;
-			}
-			
-			const oldBtcHashrate = this._btcHashrate;
-			const btcHashrateGiga = parsedData.hash_rate;
-			this._btcHashrate = btcHashrateGiga * 1000000000;
-
-			// trigger client update
-			if(oldBtcHashrate !== this._btcHashrate) {
-				this.getCharts();
-			}
-		});
-
-	}).on("error", (err) => {
-		console.error("Error while retrieving BTC hash rate: " + err.message);
-	});
-}
-
-// This API returns the BTC current hashrate value in EH/s
-History.prototype.updateBtcHashrateFromBraiinsAPI = function(source) {
+History.prototype.updateBtcHashrate = function() {
+	
+	// This API returns the BTC current hashrate value in EH/s
+	const source = 'https://insights.braiins.com/api/v1.0/hashrate-stats';
+	
 	https.get(source, (resp) => {
 		let data = '';
 
@@ -784,36 +729,6 @@ History.prototype.updateBtcHashrateFromBraiinsAPI = function(source) {
 
 	}).on("error", (err) => {
 		console.error("Error while retrieving BTC hash rate: ", err.message);
-	});
-}
-
-History.prototype.updateBtcHashrateFromAlternativeExternalSource = function(source)
-{
-	http.get(source, (resp) => {
-		let data = '';
-
-		resp.on('data', (chunk) => {
-			data += chunk;
-		});
-
-		resp.on('end', () => {
-			const parsedData = tryParseJSON(data, "Failed to update BTC hashrate. Unable to parse JSON response");
-			if (!parsedData || !parsedData.hasOwnProperty("data") || !parsedData.data.hasOwnProperty("hashrate")){
-				return;
-			}
-
-			const oldBtcHashrate = this._btcHashrate;
-			const btcHashrateExa = parsedData.data.hashrate;
-			this._btcHashrate = btcHashrateExa * 1000000000000000000;
-
-			// trigger client update
-			if(oldBtcHashrate !== this._btcHashrate) {
-				this.getCharts();
-			}
-		});
-
-	}).on("error", (err) => {
-		console.error("Error while retrieving BTC hash rate: " + err.message);
 	});
 }
 

--- a/lib/history.js
+++ b/lib/history.js
@@ -670,11 +670,15 @@ History.prototype.getHashrateComparedToBtcNetwork = function() {
 	var percentage = this._btcHashratePercentage;
 	if (rskHashrate != 0 && btcHashrate != 0) {
 		percentage = rskHashrate * 100 / btcHashrate;
+	} else {
+		console.error("Invalid rsk or btc hashing rates", rskHashrate, btcHashrate);
 	}
 
 	// Only save the new value if it's between 0 and 100
 	if (percentage >= 0 && percentage <= 100) {
 		this._btcHashratePercentage = percentage;
+	} else {
+		console.error("Invalid rsk vs btc hashing rate percentage", percentage);
 	}
 
 	return this._btcHashratePercentage < 1 ? 0 : this._btcHashratePercentage;

--- a/lib/history.js
+++ b/lib/history.js
@@ -14,6 +14,11 @@ var MAX_UNCLES = 1000;
 var MAX_UNCLES_PER_BIN = 25;
 var MAX_BINS = 40;
 
+// Adjust this value as needed as the network grows
+// Note: the reasoning here was that in general, the RSK network
+// hashrate fluctuates around 60% (this can be checked on the mining reports).
+var MAX_RSK_HASHRATE_PERCENTAGE = 61.52;
+
 var History = function History(data)
 {
 	this._items = [];
@@ -671,6 +676,11 @@ History.prototype.getHashrateComparedToBtcNetwork = function()
 	}
 
 	const percentage = rskHashrate * 100 / btcHashrate;
+
+	// TODO -> Fix me!
+	// This is done as a temporal fix as these value fluctuates a lot due to
+	// some bug (probably on the API that returns the btcHashrate)
+	if (percentage > MAX_RSK_HASHRATE_PERCENTAGE) return MAX_RSK_HASHRATE_PERCENTAGE;
 
 	return percentage < 1 ? 0 : percentage;
 }

--- a/lib/history.js
+++ b/lib/history.js
@@ -701,9 +701,9 @@ function tryParseJSON (jsonString, customErrorMessage){
 
 History.prototype.updateBtcHashrate = function() {
 	
-	// This API returns the BTC current hashrate value in EH/s
-	const source = 'https://insights.braiins.com/api/v1.0/hashrate-stats';
-	
+	// Braiins API returns BTC's current hashrate value in EH/s
+	const source = require('./utils/config').hashrateStatsApiURL;
+
 	https.get(source, (resp) => {
 		let data = '';
 

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -23,10 +23,7 @@ var banned = [
 	// '198.48.150.206'
 ];
 
-var usePrimaryBtcHashrateProvider = false;
-
 module.exports = {
 	trusted: trusted,
 	banned: banned,
-	usePrimaryBtcHashrateProvider: usePrimaryBtcHashrateProvider
 };

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -26,4 +26,5 @@ var banned = [
 module.exports = {
 	trusted: trusted,
 	banned: banned,
+	hashrateStatsApiURL: 'https://insights.braiins.com/api/v1.0/hashrate-stats'
 };


### PR DESCRIPTION
BTC hash rate was being obtained from an API that was reporting outdated values, and thus, generating wrong RSK to BTC hash rate Percentages.

A new API was included on this PR ([BRAIINS API](https://insights.braiins.com/api/v1.0/hashrate-stats)).

Additionally, a new guard was set in place in order to only return RSK vs BTC values if they're between 0 and 100 percent, if not, the previous valid value will be returned. Note that this scenario should be an exceptional one.

Logs were added in order to facilitate monitoring and notify if errors are happening.